### PR TITLE
Allow MDX files to be used

### DIFF
--- a/storybook/index.js
+++ b/storybook/index.js
@@ -24,6 +24,7 @@ const ext = [
   'json',
   'web.jsx',
   'jsx',
+  'mdx'
 ];
 
 // common function to get style loaders


### PR DESCRIPTION
Hi there,
I think that usage of this module in storybook results in mdx to not be used

I didn't verify this PR but I think that maybe by adding MDX to the extensions it would work

Was really a nice surprise to see a rescripts module with storybook since we are trying to use both of these things in our project so thank you :)