### PR TITLE
Use @rescripts/utilities

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,95 +1,29 @@
-const fs = require('fs')
 const path = require('path')
 const spawn = require('cross-spawn')
 const root = require('find-yarn-workspace-root')()
+const { getPaths, edit } = require('@rescripts/utilities')
 
-const pgks = spawn.sync('yarn', ['--json', 'workspaces', 'info'])
-const output = JSON.parse(pgks.output[1].toString())
+const rawOutput = spawn.sync('yarn', ['--json', 'workspaces', 'info'])
+const output = JSON.parse(rawOutput.output[1].toString())
 const packages = JSON.parse(output.data)
 
-const ext = [
-  'web.mjs',
-  'mjs',
-  'web.js',
-  'js',
-  'web.ts',
-  'ts',
-  'web.tsx',
-  'tsx',
-  'json',
-  'web.jsx',
-  'jsx',
-];
+const include = Object.values(packages).map(p => path.join(root, p.location))
+const exclude = /node_modules/
 
 module.exports = config => {
-  return {
-    ...config,
-    resolve: { ...config.resolve, extensions:ext.map(ext => `.${ext}`) },
-    module: {
-      ...config.module,
-      rules: [
-        ...config.module.rules,
-        {
-          test: /\.(js|mjs|jsx|ts|tsx)$/,
-          include: Object.keys(packages).map(_ => path.join(root, packages[_].location)),
-          exclude: /node_modules/,
-          loader: require.resolve('babel-loader'),
-          options: {
-            customize: require.resolve(
-              'babel-preset-react-app/webpack-overrides'
-            ),
-            // @remove-on-eject-begin
-            babelrc: false,
-            configFile: false,
-            presets: [require.resolve('babel-preset-react-app')],
-            plugins: [
-              [
-                require.resolve('babel-plugin-named-asset-import'),
-                {
-                  loaderMap: {
-                    svg: {
-                      ReactComponent:
-                        '@svgr/webpack?-svgo,+titleProp,+ref![path]',
-                    },
-                  },
-                },
-              ],
-            ],
-            // This is a feature of `babel-loader` for webpack (not Babel itself).
-            // It enables caching results in ./node_modules/.cache/babel-loader/
-            // directory for faster rebuilds.
-            cacheDirectory: true,
-            // See #6846 for context on why cacheCompression is disabled
-            cacheCompression: false,
-          },
-        },
-        {
-          test: /\.(js|mjs)$/,
-          include: Object.keys(packages).map(_ => path.join(root, packages[_].location)),
-          exclude: [/@babel(?:\/|\\{1,2})runtime/, /node_modules/],
-          loader: require.resolve('babel-loader'),
-          options: {
-            babelrc: false,
-            configFile: false,
-            compact: false,
-            presets: [
-              require.resolve('babel-preset-react-app'),
-              [
-                require.resolve('babel-preset-react-app/dependencies'),
-                { helpers: true },
-              ],
-            ],
-            cacheDirectory: true,
-            // See #6846 for context on why cacheCompression is disabled
-            cacheCompression: false,
-            // Babel sourcemaps are needed for debugging into node_modules
-            // code.  Without the options below, debuggers like VSCode
-            // show incorrect code and set breakpoints on the wrong lines.
-            sourceMaps: true,
-            inputSourceMap: true,
-          },
-        },
-      ]
-    }
-  }
+  const babelLoaderPaths = getPaths(
+    // Only use babel-loader instance with explicit includes
+    p => p && p.loader && p.loader.includes('babel-loader') && !!p.include,
+    config
+  )
+
+  return edit(
+    loader => ({
+      ...loader,
+      include: include.concat(loader.include),
+      exclude: loader.exclude ? [exclude].concat(loader.exclude) : exclude,
+    }),
+    babelLoaderPaths,
+    config
+  )
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "license": "MIT",
   "dependencies": {
     "cross-spawn": "^6.0.5",
-    "find-yarn-workspace-root": "^1.2.1"
+    "find-yarn-workspace-root": "^1.2.1",
+    "@rescripts/utilities": "^0.0.7"
   },
   "peerDependencies": {
     "react-scripts": "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,13 @@
 # yarn lockfile v1
 
 
+"@rescripts/utilities@^0.0.7":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@rescripts/utilities/-/utilities-0.0.7.tgz#fac07a981fcc9674c9b55cedb9da67f03dadda52"
+  integrity sha512-kdk4qvNYXOH7mVJCP/URokp5J+1HCR+tT1Zgtp8X9hLywn6WoKlU/tQ2ECB/NPOHrZjp/DGXWeQBAchLXV8q2w==
+  dependencies:
+    ramda "^0.26.0"
+
 arr-diff@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
@@ -509,6 +516,11 @@ posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
+
+ramda@^0.26.0:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
+  integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
 
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Uses `@rescripts/utilities` to edit loader configs in-place instead of hard-coding parts of `react-scripts` config. 
Fixes an issue we had with JS (but not TS) compilation with babel.